### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 S3 Backups
 ==========
 
-.. image:: https://pypip.in/v/s3-backups/badge.png
+.. image:: https://img.shields.io/pypi/v/s3-backups.svg
         :target: https://pypi.python.org/pypi/s3-backups
 
 .. image:: https://travis-ci.org/epicserve/s3-backups.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20s3-backups))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `s3-backups`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.